### PR TITLE
Added additional addresses for deployed contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ contract.
 - mainnet: `0xb1f8e55c7f64d203c1400b9d8555d050f94adf39`
 - ropsten: `0x8D9708f3F514206486D7E988533f770a16d074a7`
 - rinkeby: `0x3183B673f4816C94BeF53958BaF93C671B7F8Cf2`
+- kovan: `0x55ABBa8d669D60A10c104CC493ec5ef389EC92bb`
+- binance smart chain mainnet: `0xB12aeC3A7e0B8CFbA307203a33c88a3BBC0D9622`
+- binance smart chain testnet: `0x5E6F706c8Ca87c5FCbdBbfa74d69999dCDa46B24`
 
 ### Library
 


### PR DESCRIPTION
I have deployed the contracts on Binance Smart Chain Mainnet and Testnet and added these addresses (also fixing #9). Additionally I have verified all of the contracts on etherscan, so it can be trusted that their code matches, as shown in the links below.

- Kovan: https://kovan.etherscan.io/address/0x55ABBa8d669D60A10c104CC493ec5ef389EC92bb#code
- BSC Mainnet: https://bscscan.com/address/0xb12aec3a7e0b8cfba307203a33c88a3bbc0d9622#code
- BSC Testnet: https://testnet.bscscan.com/address/0x5e6f706c8ca87c5fcbdbbfa74d69999dcda46b24#code

I also have tried verifying the existing ropsten contract with 0.4.24 and 0.4.23 solidity versions unsuccessfully, could @JhonnyJason provide the version of solc for that deployment or verify it on https://ropsten.etherscan.io/address/0x8D9708f3F514206486D7E988533f770a16d074a7#code