### PR TITLE
Added Polygon and Mumbai deployed addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,10 @@ contract.
 - ropsten: `0x8D9708f3F514206486D7E988533f770a16d074a7`
 - rinkeby: `0x3183B673f4816C94BeF53958BaF93C671B7F8Cf2`
 - kovan: `0x55ABBa8d669D60A10c104CC493ec5ef389EC92bb`
-- binance smart chain mainnet: `0xB12aeC3A7e0B8CFbA307203a33c88a3BBC0D9622`
-- binance smart chain testnet: `0x5E6F706c8Ca87c5FCbdBbfa74d69999dCDa46B24`
+- binance smart chain mainnet: `0x2352c63A83f9Fd126af8676146721Fa00924d7e4`
+- binance smart chain testnet: `0x2352c63A83f9Fd126af8676146721Fa00924d7e4`
+- polygon: `0x2352c63A83f9Fd126af8676146721Fa00924d7e4`
+- mumbai: `0x2352c63A83f9Fd126af8676146721Fa00924d7e4`
 
 ### Library
 


### PR DESCRIPTION
Added Polygon and Mumbai testnet addresses provided by @liangwu

Additionally, as @liangwu also deployed the contract on BSC mainnet and testnet using the same address I have replaced my earlier addresses with the same address for ease of use.

All addresses have their source code verified:
Polygon: https://polygonscan.com/address/0x2352c63A83f9Fd126af8676146721Fa00924d7e4#code
Mumbai: https://mumbai.polygonscan.com/address/0x2352c63A83f9Fd126af8676146721Fa00924d7e4#code
BSC Mainnet: https://bscscan.com/address/0x2352c63A83f9Fd126af8676146721Fa00924d7e4#code
BSC Testnet: https://testnet.bscscan.com/address/0x2352c63a83f9fd126af8676146721fa00924d7e4#code

Fixes #9 