### PR TITLE
Added GitHub Actions support for Publishing package

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,19 @@
+name: NPM Publish
+on:
+  release:
+    types: [created]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14.x'
+          registry-url: 'https://registry.npmjs.org'
+          cache: 'yarn'
+      - run: 'yarn'
+      - run: 'yarn prepublish'
+      - run: 'npm publish --access public'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
I have added a GitHub Action that builds and publishes the package on new release

To use it NPM token has to be defined in the `NPM_TOKEN` secret

You can see an example of it working:
https://github.com/varanauskas/eth-balance-checker/runs/3660572138?check_suite_focus=true

Fixes #23 